### PR TITLE
feat: Add JumpStart Snowflake notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 This repository provides an example of how to use the [Snowflake Data Cloud](https://www.snowflake.com/) as a source of training data for training a machine learning (ML) model in Amazon SageMaker. We download the training data from a Snowflake table directly into a Amazon SageMaker training instance rather than into an Amazon S3 bucket.
 
-We use the [California Housing Dataset](https://inria.github.io/scikit-learn-mooc/python_scripts/datasets_california_housing.html) in this example to to train a regression model to predict the median house value for each district. We show how to use SageMaker Jumpstart which offers out-of-the-box low-code solutions for training models with data stored in Snowflake.
-
-For users who want more control, we also show how to write a custom training script that uses the [SageMaker XGBoost container image](https://github.com/aws/sagemaker-xgboost-container) as the base image and includes the [snowflake-python connector](https://pypi.org/project/snowflake-connector-python/) for interfacing with Snowflake.
+We use the [California Housing Dataset](https://inria.github.io/scikit-learn-mooc/python_scripts/datasets_california_housing.html) in this example to to train a regression model to predict the median house value for each district. We create a custom container for running the training job, this container uses the [SageMaker XGBoost container image](https://github.com/aws/sagemaker-xgboost-container) as the base image and includes the [snowflake-python connector](https://pypi.org/project/snowflake-connector-python/) for interfacing with Snowflake.
 
 The following figure represents the high-level architecture of the proposed solution to use Snowflake as a data source to train ML models with Amazon SageMaker.
 
 ![Architecture](img/snowflake-sagemaker-page-1.png)
+
+***New:*** For users that prefer a low-code or out of the box solution, [Amazon SageMaker JumpStart](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html) now offers XGBoost and SKLearn models with direct data integration to Snowflake. The [notebook sagemaker-snowflake-example-jumpstart.ipynb](./sagemaker-snowflake-example-jumpstart.ipynb) shows how to use JumpStart's XGBoost model to train a regressor model directly on data in Snowflake without needing to copy the data to S3 and without needing to write a custom training script.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This repository provides an example of how to use the [Snowflake Data Cloud](https://www.snowflake.com/) as a source of training data for training a machine learning (ML) model in Amazon SageMaker. We download the training data from a Snowflake table directly into a Amazon SageMaker training instance rather than into an Amazon S3 bucket.
 
-We use the [California Housing Dataset](https://inria.github.io/scikit-learn-mooc/python_scripts/datasets_california_housing.html) in this example to to train a regression model to predict the median house value for each district. We create a custom container for running the training job, this container uses the [SageMaker XGBoost container image](https://github.com/aws/sagemaker-xgboost-container) as the base image and includes the [snowflake-python connector](https://pypi.org/project/snowflake-connector-python/) for interfacing with Snowflake.
+We use the [California Housing Dataset](https://inria.github.io/scikit-learn-mooc/python_scripts/datasets_california_housing.html) in this example to to train a regression model to predict the median house value for each district. We show how to use SageMaker Jumpstart which offers out-of-the-box low-code solutions for training models with data stored in Snowflake.
+
+For users who want more control, we also show how to write a custom training script that uses the [SageMaker XGBoost container image](https://github.com/aws/sagemaker-xgboost-container) as the base image and includes the [snowflake-python connector](https://pypi.org/project/snowflake-connector-python/) for interfacing with Snowflake.
 
 The following figure represents the high-level architecture of the proposed solution to use Snowflake as a data source to train ML models with Amazon SageMaker.
 

--- a/sagemaker-snowflake-example-jumpstart.ipynb
+++ b/sagemaker-snowflake-example-jumpstart.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "1. [Objective](#Objective)\n",
     "1. [Background](#Background-(Problem-Description-and-Approach))\n",
-    "1. [Train Amazon SageMaker XGBoost Regressor with Direct Snowflake Integration](#Train-Amazon-SageMaker-XGBoost-Regressor-with-Direct-Snowflake-Integration)\n",
+    "1. [Train SageMaker JumpStart XGBoost Regressor with Direct Snowflake Integration](#Train-SageMaker-JumpStart-XGBoost-Regressor-with-Direct-Snowflake-Integration)\n",
     "1. [Conclusion](#Conclusion)"
    ]
   },
@@ -32,7 +32,7 @@
     "\n",
     "## Objective\n",
     "\n",
-    "This notebook illustrates how, in just a few lines of code, [Amazon SageMaker JumpStart](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html) XGBoost and SKLearn models with direct data integration with [Snowflake](https://www.snowflake.com/) can be used to train an ML model on Amazon SageMaker _without having to first store the Snowflake data in S3 or write a custom training script and/or algorithm container_.\n",
+    "This notebook illustrates how, in just a few lines of code, [Amazon SageMaker JumpStart](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html) XGBoost and SKLearn models with direct data integration with [Snowflake](https://www.snowflake.com/) can be used to train an ML model on SageMaker Training _without having to first store the Snowflake data in S3 or write a custom training script and/or algorithm container_.\n",
     "\n",
     "This example uses the [California Housing dataset (provided by Scikit-Learn)](https://scikit-learn.org/stable/modules/generated/sklearn.datasets.fetch_california_housing.html) and trains a XGBoost model to predict house prices. A detailed description about the dataset can be found [here](https://inria.github.io/scikit-learn-mooc/python_scripts/datasets_california_housing.html).\n",
     "\n",
@@ -48,7 +48,7 @@
     "\n",
     "- **Problem statement**: SageMaker requires the training data to be present either in [S3 or in EFS or in FSX for Lustre](https://aws.amazon.com/blogs/machine-learning/choose-the-best-data-source-for-your-amazon-sagemaker-training-job/). In order to train a model using data stored outside of the three supported storage services, the data first needs to be ingested into one of these services (typically S3). This requires building a data pipeline (using tools such as [Amazon SageMaker Data Wrangler](https://aws.amazon.com/sagemaker/data-wrangler/)) to move data into S3. However, this may create a data management challenge in some situations (data lifecycle management, access control etc.) and it may be desirable to have the data accessible to SageMaker _without_ the intermediate storage of data into S3. This notebook illustrates a way to do this using Snowflake as a 3rd party data source.\n",
     "\n",
-    "- **Our approach**: Use SageMaker JumpStart to start a SageMaker Training Job in just a few lines of code. SageMaker JumpStart offers XGBoost and SciKit-Learn models `xgboost-classification-snowflake`, `xgboost-regression-snowflake`, `sklearn-classification-snowflake`, and `sklearn-regression-snowflake` that download the data from Snowflake directly into the instance created for running the training job, thus avoiding the temporary storage of data in S3. **Note that it is assumed that the data is already available in Snowflake, see [`snowflake instructions`](./snowflake-instructions.md) for instructions on creating a database in Snowflake and ingesting the California Housing dataset as a table.**\n",
+    "- **Our approach**: Use [Amazon SageMaker JumpStart](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html) to [start a SageMaker Training Job in just a few lines of code](https://sagemaker.readthedocs.io/en/stable/overview.html#low-code-fine-tuning-with-the-jumpstartestimator-class). JumpStart offers XGBoost and SciKit-Learn models `xgboost-classification-snowflake`, `xgboost-regression-snowflake`, `sklearn-classification-snowflake`, and `sklearn-regression-snowflake` that download the data from Snowflake directly into the instance created for running the training job, thus avoiding the temporary storage of data in S3. **Note that it is assumed that the data is already available in Snowflake, see [`snowflake instructions`](./snowflake-instructions.md) for instructions on creating a database in Snowflake and ingesting the California Housing dataset as a table.**\n",
     "\n",
     "- **Our tools**: [Amazon SageMaker Python SDK](https://sagemaker.readthedocs.io/en/stable/) and [Amazon SageMaker JumpStart's low-code Estimator class in the SageMaker Python SDK](https://sagemaker.readthedocs.io/en/stable/overview.html#low-code-fine-tuning-with-the-jumpstartestimator-class).\n"
    ]

--- a/sagemaker-snowflake-example-jumpstart.ipynb
+++ b/sagemaker-snowflake-example-jumpstart.ipynb
@@ -1,0 +1,296 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "4bdcbdd3",
+   "metadata": {},
+   "source": [
+    "# Snowflake as Data Source for training an ML Model with Amazon Sagemaker\n",
+    "**_Use of Snowflake Data Table as Data Source and SageMaker JumpStart to train machine learning models without having Snowflake Data to stage on S3_**\n",
+    "\n",
+    "This notebook works well with the `conda_python3` kernel on a SageMaker Notebook `ml.t3.xlarge` instance.\n",
+    "\n",
+    "---\n",
+    "---\n",
+    "\n",
+    "## Contents\n",
+    "\n",
+    "1. [Objective](#Objective)\n",
+    "1. [Background](#Background-(Problem-Description-and-Approach))\n",
+    "1. [Train an XGBoost Regression using SageMaker JumpStart + Snowflake data](#Train-an-XGBoost-Regressor-using-SageMaker-JumpStart)\n",
+    "1. [Conclusion](#Conclusion)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "dd4334f4",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Objective\n",
+    "\n",
+    "This notebook illustrates how, in just a few lines of code, [Amazon SageMaker JumpStart](https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jumpstart.html) XGBoost and SKLearn models with direct data integration with [Snowflake](https://www.snowflake.com/) can be used to train an ML model on Amazon SageMaker _without having to first store the Snowflake data in S3 or write a custom training script and/or algorithm container_.\n",
+    "\n",
+    "This example uses the [California Housing dataset (provided by Scikit-Learn)](https://scikit-learn.org/stable/modules/generated/sklearn.datasets.fetch_california_housing.html) and trains a XGBoost model to predict house prices. A detailed description about the dataset can be found [here](https://inria.github.io/scikit-learn-mooc/python_scripts/datasets_california_housing.html).\n",
+    "\n",
+    "To understand the code, you might also find it useful to refer to:\n",
+    "\n",
+    "- *The [documentation on SageMaker JumpStart's low-code Estimator class in the SageMaker Python SDK](https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html#sagemaker.jumpstart.estimator.JumpStartEstimator)*\n",
+    "- *The [examples of low-code training using SageMaker JumpStart's low-code Estimator class in the SageMaker Python SDK](https://sagemaker.readthedocs.io/en/stable/overview.html#low-code-fine-tuning-with-the-jumpstartestimator-class)*\n",
+    "- *The guide on [Use XGBoost with the SageMaker Python SDK](https://sagemaker.readthedocs.io/en/stable/frameworks/xgboost/using_xgboost.html#)*\n",
+    "- *The [SageMaker reference for Boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#client) (The general AWS SDK for Python, including low-level bindings for SageMaker as well as many other AWS services)*\n",
+    "---\n",
+    "\n",
+    "## Background (Problem Description and Approach)\n",
+    "\n",
+    "- **Problem statement**: SageMaker requires the training data to be present either in [S3 or in EFS or in FSX for Lustre](https://aws.amazon.com/blogs/machine-learning/choose-the-best-data-source-for-your-amazon-sagemaker-training-job/). In order to train a model using data stored outside of the three supported storage services, the data first needs to be ingested into one of these services (typically S3). This requires building a data pipeline (using tools such as [Amazon SageMaker Data Wrangler](https://aws.amazon.com/sagemaker/data-wrangler/)) to move data into S3. However, this may create a data management challenge in some situations (data lifecycle management, access control etc.) and it may be desirable to have the data accessible to SageMaker _without_ the intermediate storage of data into S3. This notebook illustrates a way to do this using Snowflake as a 3rd party data source.\n",
+    "\n",
+    "- **Our approach**: Use SageMaker JumpStart to start a SageMaker Training Job in just a few lines of code. SageMaker JumpStart offers XGBoost and SciKit-Learn models `xgboost-classification-snowflake`, `xgboost-regression-snowflake`, `sklearn-classification-snowflake`, and `sklearn-regression-snowflake` that download the data from Snowflake directly into the instance created for running the training job, thus avoiding the temporary storage of data in S3. **Note that it is assumed that the data is already available in Snowflake, see [`snowflake instructions`](./snowflake-instructions.md) for instructions on creating a database in Snowflake and ingesting the California Housing dataset as a table.**\n",
+    "\n",
+    "- **Our tools**: [Amazon SageMaker Python SDK](https://sagemaker.readthedocs.io/en/stable/) and [Amazon SageMaker JumpStart's low-code Estimator class in the SageMaker Python SDK](https://sagemaker.readthedocs.io/en/stable/overview.html#low-code-fine-tuning-with-the-jumpstartestimator-class).\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "ecb65b13",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Pre-requisites\n",
+    "\n",
+    "Steps 1 and 2 are executed outside of this notebook. \n",
+    "\n",
+    "1. See [`snowflake instructions`](./snowflake-instructions.md) for instructions on creating a database in Snowflake and ingesting the California Housing dataset as a table.\n",
+    "1. See [`secrets manager instructions`](./secretsmanager-instructions.md) for instructions on storing Snowflake credentials that will be used for SageMaker Training Jobs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f1bd5cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install sagemaker==2.168.0 --upgrade"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "910747a4",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Train an XGBoost Regressor using SageMaker JumpStart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37a8d500",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%store -r sf_account_id\n",
+    "%store -r sf_secret_id\n",
+    "print(f\"sf_account_id={sf_account_id}, sf_secret_id={sf_secret_id}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "809447f3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "\n",
+    "# do not change!!!\n",
+    "# the values of these variables match what we put in the snowflake-load-dataset.ipynb file\n",
+    "warehouse = \"amazon_sagemake_w_snowflake_as_datasource\"\n",
+    "database = \"housing\"\n",
+    "schema = \"housing_schema\"\n",
+    "training_table = \"california_housing\"\n",
+    "session = boto3.session.Session()\n",
+    "region = session.region_name\n",
+    "print(f\"region={region}\")\n",
+    "\n",
+    "# The environment variable SF_VALIDATION_TABLE is optional. If not specified,\n",
+    "# part of the training data will be used as validation.\n",
+    "environment = {\n",
+    "       \"SF_ACCOUNT_ID\": sf_account_id,\n",
+    "       \"SF_SECRET_ID\": sf_secret_id,\n",
+    "       \"SF_WAREHOUSE\": warehouse,\n",
+    "       \"SF_DATABASE\": database,\n",
+    "       \"SF_SCHEMA\": schema,\n",
+    "       \"SF_TRAINING_TABLE\": training_table,\n",
+    "       \"AWS_REGION\": region,\n",
+    "}"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "9b8f0ed2",
+   "metadata": {},
+   "source": [
+    "## Launch a training job using SageMaker JumpStart\n",
+    "\n",
+    "SageMaker JumpStart now offers four new models with direct Snowflake integration:\n",
+    "1. `xgboost-regression-snowflake`\n",
+    "2. `xgboost-classification-snowflake`\n",
+    "3. `sklearn-regression-snowflake`\n",
+    "4. `sklearn-classification-snowflake`\n",
+    "\n",
+    "These models can be easily trained programatically via the [JumpStartEstimator class in the SageMaker Python SDK](https://sagemaker.readthedocs.io/en/stable/overview.html#low-code-fine-tuning-with-the-jumpstartestimator-class).\n",
+    "\n",
+    "SageMaker JumpStart and the SageMaker Python SDK make training these models easy by providing defaults for instance types and hyperparameters so users don't need to explicitly specify these parameters out of the box.*\n",
+    "\n",
+    "**Users who wish to modify these defaults to their use case can do so by [modifying the arguments to the JumpStart estimator.](https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html#sagemaker.jumpstart.estimator.JumpStartEstimator)*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ce319ad",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "import sagemaker\n",
+    "from sagemaker import get_execution_role\n",
+    "from sagemaker.jumpstart.estimator import JumpStartEstimator\n",
+    "\n",
+    "role = get_execution_role()\n",
+    "sm_session = sagemaker.Session()\n",
+    "bucket = None  # optionally specify your bucket here, eg: 'mybucket-us-east-1'; Otherwise, SageMaker will use\n",
+    "# the default acct bucket to upload model artifacts\n",
+    "if bucket is None and sm_session is not None:\n",
+    "    bucket = sm_session.default_bucket()\n",
+    "print(f\"bucket={bucket}, role={role}\")\n",
+    "prefix = \"sagemaker/sagemaker-jumpstart-snowflake-example\"\n",
+    "output_path = f\"s3://{bucket}/{prefix}/housing-dist-xgb/output\"\n",
+    "\n",
+    "model_id = \"xgboost-regression-snowflake\"\n",
+    "# SageMaker JumpStart also offers Snowflake direct integration with these models:\n",
+    "# model_id = \"xgboost-classification-snowflake\"\n",
+    "# model_id = \"sklearn-regression-snowflake\"\n",
+    "# model_id = \"sklearn-classification-snowflake\"\n",
+    "\n",
+    "# collect default subnet IDs to deploy Sagemaker training job into\n",
+    "ec2_session = boto3.Session(region_name=region)\n",
+    "ec2_resource = ec2_session.resource(\"ec2\")\n",
+    "subnet_ids = []\n",
+    "for vpc in ec2_resource.vpcs.all():\n",
+    "    # here you can choose which subnet based on the id\n",
+    "    if vpc.is_default == True:\n",
+    "        for subnet in vpc.subnets.all():\n",
+    "            if subnet.default_for_az == True:\n",
+    "                subnet_ids.append(subnet.id)\n",
+    "\n",
+    "# SageMaker JumpStart makes model training easy by defining defaults for instance\n",
+    "# types and hyperparameters so you don't have to. These parameters can still be\n",
+    "# modified by the user, but this is not necessary out of the box.\n",
+    "xgb_snowflake_estimator = JumpStartEstimator(\n",
+    "    model_id=model_id,\n",
+    "    role=role,\n",
+    "    output_path=f\"s3://{bucket}/{prefix}/output\",\n",
+    "    sagemaker_session=sm_session,\n",
+    "    environment=environment,\n",
+    "    subnets=subnet_ids,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf2f6891",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Estimator fitting\n",
+    "xgb_snowflake_estimator.fit()\n",
+    "# Optional: Deploy the model to a SageMaker Inference Endpoint with one line of code with SageMaker JumpStart\n",
+    "# xgb_snowflake_estimator.deploy()\n",
+    "# If you deploy the endpoint remember to clean it up to avoid incurring any future charges!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ee9c554",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print(f\"the trained model is available in S3 -> {xgb_snowflake_estimator.model_data}\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "c252de2c",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Cleaning up\n",
+    "\n",
+    "To avoid incurring future charges, delete the resources. You can do this by deleting the cloud formation template used to create the IAM role and the Amazon SageMaker Notebook.\n",
+    "![Cleaning Up](img/cfn-delete.png)\n",
+    "\n",
+    "You will have to delete the Snowflake resources manually from the Snowflake console."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "0782db29",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Conclusion\n",
+    "\n",
+    "In this notebook we saw how Amazon SageMaker JumpStart can be used to quickly train an XGBoost model directly from data stored in Snowflake in just a few lines of code. **SageMaker JumpStart directly integrates Snowflake as a data source with Sagemaker Training without having the data staged on S3.**"
+   ]
+  }
+ ],
+ "metadata": {
+  "instance_type": "ml.t3.medium",
+  "kernelspec": {
+   "display_name": "model-hub",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/sagemaker-snowflake-example-jumpstart.ipynb
+++ b/sagemaker-snowflake-example-jumpstart.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "1. [Objective](#Objective)\n",
     "1. [Background](#Background-(Problem-Description-and-Approach))\n",
-    "1. [Train an XGBoost Regression using SageMaker JumpStart + Snowflake data](#Train-an-XGBoost-Regressor-using-SageMaker-JumpStart)\n",
+    "1. [Train Amazon SageMaker XGBoost Regressor with Direct Snowflake Integration](#Train-Amazon-SageMaker-XGBoost-Regressor-with-Direct-Snowflake-Integration)\n",
     "1. [Conclusion](#Conclusion)"
    ]
   },
@@ -87,7 +87,16 @@
    "source": [
     "---\n",
     "\n",
-    "## Train an XGBoost Regressor using SageMaker JumpStart"
+    "## Train SageMaker JumpStart XGBoost Regressor with Direct Snowflake Integration"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "d1f0d350",
+   "metadata": {},
+   "source": [
+    "### Environment setup"
    ]
   },
   {
@@ -144,7 +153,7 @@
    "id": "9b8f0ed2",
    "metadata": {},
    "source": [
-    "## Launch a training job using SageMaker JumpStart\n",
+    "### Fetch SageMaker JumpStart models with direct Snowflake integration\n",
     "\n",
     "SageMaker JumpStart now offers four new models with direct Snowflake integration:\n",
     "1. `xgboost-regression-snowflake`\n",
@@ -214,6 +223,15 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "c428c7d6",
+   "metadata": {},
+   "source": [
+    "### Train JumpStart XGBoost model with direct Snowflake integration"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "cf2f6891",
@@ -222,7 +240,7 @@
    },
    "outputs": [],
    "source": [
-    "# Estimator fitting\n",
+    "# Estimator fitting. Data from Snowflake will be downloaded onto the compute instance during the training job\n",
     "xgb_snowflake_estimator.fit()\n",
     "# Optional: Deploy the model to a SageMaker Inference Endpoint with one line of code with SageMaker JumpStart\n",
     "# xgb_snowflake_estimator.deploy()\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add JumpStart Snowflake notebook. 

Amazon SageMaker JumpStart now offers four new models that have direct data integration with Snowflake:
1. `xgboost-regression-snowflake`
2. `xgboost-classification-snowflake`
3. `sklearn-regression-snowflake`
4. `sklearn-classification-snowflake`

These can be used by customers via the SageMaker Python SDK like so:

```python3
environment = {
       "SF_ACCOUNT_ID": sf_account_id,
       "SF_SECRET_ID": sf_secret_id,
       "SF_WAREHOUSE": warehouse,
       "SF_DATABASE": database,
       "SF_SCHEMA": schema,
       "SF_TRAINING_TABLE": training_table,
       "AWS_REGION": region,
}
model_id = "xgboost-regression-snowflake"
xgb_snowflake_estimator = JumpStartEstimator(
    model_id=model_id,
    environment=environment,
)
xgb_snowflake_estimator.fit()
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
